### PR TITLE
fix error in 'removeAlllisteners' function

### DIFF
--- a/Plus.php
+++ b/Plus.php
@@ -330,7 +330,7 @@ Class EventEmitter extends Prototype
      */
     public function removeAllListeners($event = null)
     {
-        if ( empty($event) )
+        if ( !empty($event) )
             unset($this->listeners[$event]);
         else
             $this->listeners = array();


### PR DESCRIPTION
There is a jugement error in 'removeAlllisteners' function of EventEmiter class(sorry for my poor english)
